### PR TITLE
Title pages curriculumId and learningUnitId

### DIFF
--- a/components/curriculums/CurriculumInformation.js
+++ b/components/curriculums/CurriculumInformation.js
@@ -1,15 +1,13 @@
 import { Typography, Alert, Card, CardContent } from "@mui/material";
-import { useOperation } from "react-openapi-client";
 import Loader from "../common/Loader";
+import useFetch from "../../hooks/use-fetch";
 
 export default function CurriculumInformation({ curriculumId }) {
-  const {
-    loading,
-    data: curriculum,
-    error,
-  } = useOperation("getCurriculum", curriculumId);
+  const { data: curriculum, error } = useFetch(
+    `/api/curriculums/${curriculumId}`
+  );
 
-  if (loading) {
+  if (!curriculum) {
     return <Loader />;
   }
 

--- a/components/curriculums/CurriculumInformation.js
+++ b/components/curriculums/CurriculumInformation.js
@@ -1,0 +1,25 @@
+import { Typography, Alert } from "@mui/material";
+import { useOperation } from "react-openapi-client";
+import Loader from "../common/Loader";
+
+export default function CurriculumInformation({ curriculumId }) {
+  const {
+    loading,
+    data: curriculum,
+    error,
+  } = useOperation("getCurriculum", curriculumId);
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (error) {
+    return <Alert severity="error">Error</Alert>;
+  }
+
+  return (
+    <Typography variant="h2" component="div">
+      {curriculum.name}
+    </Typography>
+  );
+}

--- a/components/learningUnits/LearningUnitInfo.js
+++ b/components/learningUnits/LearningUnitInfo.js
@@ -2,12 +2,12 @@ import { Typography, Alert, Card, CardContent } from "@mui/material";
 import { useOperation } from "react-openapi-client";
 import Loader from "../common/Loader";
 
-export default function CurriculumInformation({ curriculumId }) {
+export default function LearningUnitInformation({ learningUnitId }) {
   const {
     loading,
-    data: curriculum,
+    data: learningUnit,
     error,
-  } = useOperation("getCurriculum", curriculumId);
+  } = useOperation("getLearningUnit", learningUnitId);
 
   if (loading) {
     return <Loader />;
@@ -21,7 +21,7 @@ export default function CurriculumInformation({ curriculumId }) {
     <Card>
       <CardContent>
         <Typography variant="h2" component="div">
-          {curriculum.name}
+          {learningUnit.name}
         </Typography>
       </CardContent>
     </Card>

--- a/components/learningUnits/LearningUnitInfo.js
+++ b/components/learningUnits/LearningUnitInfo.js
@@ -1,15 +1,13 @@
 import { Typography, Alert, Card, CardContent } from "@mui/material";
-import { useOperation } from "react-openapi-client";
 import Loader from "../common/Loader";
+import useFetch from "../../hooks/use-fetch";
 
 export default function LearningUnitInformation({ learningUnitId }) {
-  const {
-    loading,
-    data: learningUnit,
-    error,
-  } = useOperation("getLearningUnit", learningUnitId);
+  const { data: learningUnit, error } = useFetch(
+    `/api/learning_units/${learningUnitId}`
+  );
 
-  if (loading) {
+  if (!learningUnit) {
     return <Loader />;
   }
 

--- a/pages/curriculums/[curriculumId].js
+++ b/pages/curriculums/[curriculumId].js
@@ -2,6 +2,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import LearningUnitsOfCurriculum from "../../components/learningUnits/LearningUnitsOfCurriculum";
 import Loader from "../../components/common/Loader";
+import CurriculumInformation from "../../components/curriculums/CurriculumInformation";
 
 export default function LearningUnits() {
   const { query, isReady } = useRouter();
@@ -10,5 +11,10 @@ export default function LearningUnits() {
   }
 
   const { curriculumId } = query;
-  return <LearningUnitsOfCurriculum curriculumId={curriculumId} />;
+  return (
+    <React.StrictMode>
+      <CurriculumInformation curriculumId={curriculumId} />
+      <LearningUnitsOfCurriculum curriculumId={curriculumId} />
+    </React.StrictMode>
+  );
 }

--- a/pages/learningUnits/[learningUnitId].js
+++ b/pages/learningUnits/[learningUnitId].js
@@ -2,6 +2,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import ResourcesOfLearningUnit from "../../components/resources/ResourcesOfLearningUnit";
 import Loader from "../../components/common/Loader";
+import LearningUnitInformation from "../../components/learningUnits/LearningUnitInfo";
 
 export default function LearningUnits() {
   const { query, isReady } = useRouter();
@@ -12,6 +13,7 @@ export default function LearningUnits() {
   const { learningUnitId } = query;
   return (
     <React.StrictMode>
+      <LearningUnitInformation learningUnitId={learningUnitId} />
       <ResourcesOfLearningUnit learningUnitId={learningUnitId} />
     </React.StrictMode>
   );


### PR DESCRIPTION
This PR adds a `CurriculumInformation` and `LearningUnitInformation` component to the `curriculum/[curriculumId]` and `learningUnit/[LearningUnitId]` pages, respectively. 
These components show the name of the curriculum/learning unit in the page of the element.

> It's necessary to update to the latest version of the backend because the component `LearningUnitInformation` uses an endpoint not available before.