### PR TITLE
feat: Error component as a snackbar with an alert

### DIFF
--- a/components/common/Error.js
+++ b/components/common/Error.js
@@ -1,0 +1,23 @@
+import { Snackbar, Alert } from "@mui/material";
+import { useState } from "react";
+
+export default function Error({ message }) {
+  const [open, setOpen] = useState(true);
+  const handleClose = () => setOpen(!open);
+  const errorMessage =
+    message === undefined ? "Could not perform operation" : message;
+
+  return (
+    <Snackbar
+      anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      open={open}
+      onClose={handleClose}
+      autoHideDuration={6000}
+      key="bottomleft"
+    >
+      <Alert onClose={handleClose} severity="error" sx={{ width: "100%" }}>
+        {errorMessage}
+      </Alert>
+    </Snackbar>
+  );
+}


### PR DESCRIPTION
A common component to render errors. You can call it with a custom message, otherwise it will say "Operation could not be performed".

In a future PR I'll try to implement it in the resource and resourceComment forms, it's not that simple because you can't call it from within a modal or something.